### PR TITLE
Avoid to substitute with spaces // #code to maintain indentation

### DIFF
--- a/preprocessor.ts
+++ b/preprocessor.ts
@@ -269,7 +269,7 @@ function reveal_code(lines: string[], start: number, end: number) {
    for(let t=start; t<=end; t++) {
       let r = regex.exec(lines[t]);
       if(r!==null && r.groups!==undefined) {
-         lines[t] = " ".repeat(r.groups.before.length) + r.groups.line;
+         lines[t] = "".repeat(r.groups.before.length) + r.groups.line;
       }
    }
 }


### PR DESCRIPTION
eslint will otherwise complain about wrong indentation